### PR TITLE
Fix solo config being not seralizable

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -340,4 +340,18 @@ class Command implements Loopable
         // Primarily here for any subclasses.
         return $lines;
     }
+
+    public static function __set_state(array $data)
+    {
+        $instance = new static();
+
+        // Set all the properties on the instance.
+        foreach ($data as $key => $value) {
+            $reflection = new \ReflectionProperty($instance, $key);
+            $reflection->setAccessible(true);
+            $reflection->setValue($instance, $value);
+        }
+
+        return $instance;
+    }
 }


### PR DESCRIPTION
Hey! First up, thanks for the excellent package. 

This is a fix for #55  (exception being thrown when caching Laravel config due to the `Commands` class not being serializable.

I tried adding `__serialize` and `__unserialize`, but found it wasn't actually being called. Instead, it was expecting a `__set_state` function, caused by the cache command using `var_dump`.

![image](https://github.com/user-attachments/assets/a465a650-fa3f-4385-8304-09127f678fce)

The fix just sets `__set_state` to return a new instance, with every property set to the value set when registered in the confg