### PR TITLE
Chaned default reverb command in config

### DIFF
--- a/config/solo.php
+++ b/config/solo.php
@@ -54,7 +54,7 @@ return [
 
         // Lazy commands do no automatically start when Solo starts.
         'Dumps' => Command::from('php artisan solo:dumps')->lazy(),
-        'Reverb' => Command::from('php artisan reverb')->lazy(),
+        'Reverb' => Command::from('php artisan reverb:start --debug')->lazy(),
         'Pint' => Command::from('./vendor/bin/pint --ansi')->lazy(),
         'Queue' => Command::from('php artisan queue:work')->lazy(),
         'Tests' => Command::from('php artisan test --colors=always')->lazy(),


### PR DESCRIPTION
Changed the reverb command to be `php artisan reverb:start` as `php artisan reverb` is not a command. Also added in `--debug` to get output from the server, there are no output without it. This is how 99% of people would use this command.