### PR TITLE
Fix/laravel version support

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -102,6 +102,14 @@ class Manager
         return $this;
     }
 
+    private function checkType(mixed $value, string $type): void
+    {
+        $actualType = gettype($value);
+        if ($actualType !== $type) {
+            throw new InvalidArgumentException("Config value must be of type {$type}, {$actualType} given.");
+        }
+    }
+
     /**
      * @return array<Hotkey>
      *
@@ -111,6 +119,9 @@ class Manager
     {
         $bindings = Config::array('solo.keybindings', []);
         $binding = Config::string('solo.keybinding', 'default');
+        $bindings = Config::get('solo.keybindings', []);
+
+        $binding = Config::get('solo.keybinding', 'default');
 
         $hotkeys = Arr::get($bindings, $binding, DefaultHotkeys::class);
 
@@ -129,6 +140,9 @@ class Manager
 
         $theme = Config::string('solo.theme', 'light');
         $themes = Config::array('solo.themes', [
+        $theme = Config::get('solo.theme', 'light');
+
+        $themes = Config::get('solo.themes', [
             'light' => LightTheme::class,
         ]);
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -117,11 +117,11 @@ class Manager
      */
     public function hotkeys(): array
     {
-        $bindings = Config::array('solo.keybindings', []);
-        $binding = Config::string('solo.keybinding', 'default');
         $bindings = Config::get('solo.keybindings', []);
+        $this->checkType($bindings, 'array');
 
         $binding = Config::get('solo.keybinding', 'default');
+        $this->checkType($binding, 'string');
 
         $hotkeys = Arr::get($bindings, $binding, DefaultHotkeys::class);
 
@@ -138,13 +138,13 @@ class Manager
             return $this->cachedTheme;
         }
 
-        $theme = Config::string('solo.theme', 'light');
-        $themes = Config::array('solo.themes', [
         $theme = Config::get('solo.theme', 'light');
+        $this->checkType($theme, 'string');
 
         $themes = Config::get('solo.themes', [
             'light' => LightTheme::class,
         ]);
+        $this->checkType($themes, 'array');
 
         $theme = Arr::get($themes, $theme, $theme);
 


### PR DESCRIPTION
This PR removed the use of the Config methods for a specific typed value (string & array) to support Laravel 10.x where they had not yet been implemented. This will close # and prevent the test errors when on the github actions when prefers lowest runs (https://github.com/soloterm/solo/actions/runs/13204165126/job/36863231387).