### PR TITLE
Feat: Added chainable `createIfMissing()` method on `EnhancedTailCommand` class

### DIFF
--- a/config/solo.php
+++ b/config/solo.php
@@ -47,7 +47,7 @@ return [
     */
     'commands' => [
         'About' => 'php artisan solo:about',
-        'Logs' => EnhancedTailCommand::file(storage_path('logs/laravel.log')),
+        'Logs' => EnhancedTailCommand::file(storage_path('logs/laravel.log'))->createIfMissing(),
         'Vite' => 'npm run dev',
         'Make' => new MakeCommand,
         // 'HTTP' => 'php artisan serve',

--- a/src/Commands/EnhancedTailCommand.php
+++ b/src/Commands/EnhancedTailCommand.php
@@ -23,6 +23,8 @@ class EnhancedTailCommand extends Command
 
     protected bool $hideVendor = true;
 
+    protected bool $shouldCreateMissingLogFile = false;
+
     protected int $compressed = 0;
 
     protected ?int $pendingScrollIndex = null;
@@ -39,6 +41,15 @@ class EnhancedTailCommand extends Command
     public function setFile($path)
     {
         $this->file = $path;
+
+        $this->createLogFileIfMissing();
+
+        return $this;
+    }
+
+    public function createIfMissing(): self
+    {
+        $this->shouldCreateMissingLogFile = true;
 
         return $this;
     }
@@ -313,5 +324,18 @@ class EnhancedTailCommand extends Command
             str_contains($line, '/vendor/') && !Str::isMatch("/BoundMethod\.php\([0-9]+\): App/", $line)
             ||
             str_ends_with($line, '{main}');
+    }
+
+    protected function isLogFileMissing(): bool
+    {
+        return !is_null($this->file) && !file_exists($this->file);
+    }
+
+    protected function createLogFileIfMissing(): bool
+    {
+        if ($this->shouldCreateMissingLogFile && $this->isLogFileMissing()) {
+            return touch($this->file);
+        }
+        return true;
     }
 }

--- a/src/Commands/EnhancedTailCommand.php
+++ b/src/Commands/EnhancedTailCommand.php
@@ -23,8 +23,6 @@ class EnhancedTailCommand extends Command
 
     protected bool $hideVendor = true;
 
-    protected bool $shouldCreateMissingLogFile = false;
-
     protected int $compressed = 0;
 
     protected ?int $pendingScrollIndex = null;
@@ -42,14 +40,12 @@ class EnhancedTailCommand extends Command
     {
         $this->file = $path;
 
-        $this->createLogFileIfMissing();
-
         return $this;
     }
 
     public function createIfMissing(): self
     {
-        $this->shouldCreateMissingLogFile = true;
+        $this->createLogFileIfMissing();
 
         return $this;
     }
@@ -333,7 +329,7 @@ class EnhancedTailCommand extends Command
 
     protected function createLogFileIfMissing(): bool
     {
-        if ($this->shouldCreateMissingLogFile && $this->isLogFileMissing()) {
+        if ($this->isLogFileMissing()) {
             return touch($this->file);
         }
         return true;


### PR DESCRIPTION
Created a simple `createIfMissing()` method that can be chained onto the `EnhancedTailCommand` class that creates the log file if it is missing.

**Solves:** This will remove the error when no log file exists.

Also added it by default, since when a new project is created the log file is not there by default.
Did not see any tests for the class, but tested it locally and seems good.