### PR TITLE
Fix typo in published config file

### DIFF
--- a/config/solo.php
+++ b/config/solo.php
@@ -52,7 +52,7 @@ return [
         'Make' => new MakeCommand,
         // 'HTTP' => 'php artisan serve',
 
-        // Lazy commands do no automatically start when Solo starts.
+        // Lazy commands do not automatically start when Solo starts.
         'Dumps' => Command::from('php artisan solo:dumps')->lazy(),
         'Reverb' => Command::from('php artisan reverb:start --debug')->lazy(),
         'Pint' => Command::from('./vendor/bin/pint --ansi')->lazy(),


### PR DESCRIPTION
I see you all toiling on those backspaces and deletes, but I am afraid you are loosing track of the weightier matters of a codebase: **_Perfect comments!_**

In all seriousness though, keep it up — `solo` ~~is becoming~~ has become my go-to for local development.