### PR TITLE
Fix minor typo in config

### DIFF
--- a/workbench/config/solo.php
+++ b/workbench/config/solo.php
@@ -21,7 +21,7 @@ return [
         'Make' => new MakeCommand,
         // 'HTTP' => 'php artisan serve',
 
-        // Lazy commands do no automatically start when Solo starts.
+        // Lazy commands do not automatically start when Solo starts.
         'Dumps' => Command::from('php artisan solo:dumps')->lazy(),
         'Reverb' => Command::from('php artisan reverb')->lazy(),
         'Pint' => Command::from('./vendor/bin/pint --ansi')->lazy(),


### PR DESCRIPTION
Just fixing a minor typo in the config:

`Lazy commands do no` -> `Lazy commands do not`