### PR TITLE
Add dev keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
     "name": "soloterm/solo",
     "description": "A Laravel package to run multiple commands at once, to aid in local development.",
     "type": "library",
+    "keywords": [
+        "dev"
+    ],
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
As this package is meant for development, it's advised to add a special `dev` keyword to composer.json.

> Some special keywords trigger `composer require` without the `--dev` option to prompt users if they would like to add these packages to `require-dev` instead of require. These are: `dev`, `testing`, `static analysis`.

See: https://getcomposer.org/doc/04-schema.md#keywords