### PR TITLE
Add some hotkeys

### DIFF
--- a/src/Hotkeys/DefaultHotkeys.php
+++ b/src/Hotkeys/DefaultHotkeys.php
@@ -66,6 +66,16 @@ class DefaultHotkeys implements HotkeyProvider
                 ->label('Next')
                 ->invisible(),
 
+            // CTRL + LEFT_ARROW
+            'head_tab' => Hotkey::make("\e[1;5D", KeyHandler::HeadTab)
+                ->label('Head')
+                ->invisible(),
+
+            // CTRL + RIGHT_ARROW
+            'tail_tab' => Hotkey::make("\e[1;5C", KeyHandler::TailTab)
+                ->label('Tail')
+                ->invisible(),
+
             // This is a no-op, display only key. The real scroll handlers are
             // right below, but they're invisible. We do this to save space.
             'scroll' => Hotkey::make()

--- a/src/Hotkeys/KeyHandler.php
+++ b/src/Hotkeys/KeyHandler.php
@@ -37,6 +37,8 @@ enum KeyHandler
     case Restart;
     case PreviousTab;
     case NextTab;
+    case HeadTab;
+    case TailTab;
     case Interactive;
 
     // Application
@@ -59,6 +61,8 @@ enum KeyHandler
             self::Quit => fn(Dashboard $prompt) => $prompt->quit(),
             self::PreviousTab => fn(Dashboard $prompt) => $prompt->previousTab(),
             self::NextTab => fn(Dashboard $prompt) => $prompt->nextTab(),
+            self::HeadTab => fn(Dashboard $prompt) => $prompt->headTab(),
+            self::TailTab => fn(Dashboard $prompt) => $prompt->tailTab(),
             self::ScrollUp => fn(Command $command) => $command->scrollUp(),
             self::ScrollDown => fn(Command $command) => $command->scrollDown(),
             self::PageUp => fn(Command $command) => $command->pageUp(),

--- a/src/Hotkeys/VimHotkeys.php
+++ b/src/Hotkeys/VimHotkeys.php
@@ -32,6 +32,8 @@ class VimHotkeys extends DefaultHotkeys
 
         $map['previous_tab']->remap('h');
         $map['next_tab']->remap('l');
+        $map['head_tab']->remap('^');
+        $map['tail_tab']->remap('$');
         $map['scroll_up']->remap('k');
         $map['scroll_down']->remap('j');
         $map['page_up']->remap(Key::CTRL_U);

--- a/src/Prompt/Dashboard.php
+++ b/src/Prompt/Dashboard.php
@@ -204,6 +204,16 @@ class Dashboard extends Prompt
         );
     }
 
+    public function headTab()
+    {
+        $this->selectTab(0);
+    }
+
+    public function tailTab()
+    {
+        $this->selectTab(count($this->commands) - 1);
+    }
+
     protected function showDashboard(): void
     {
         $this->currentCommand()->focus($this);

--- a/tests/Integration/HotkeyTest.php
+++ b/tests/Integration/HotkeyTest.php
@@ -11,6 +11,7 @@ namespace SoloTerm\Solo\Tests\Integration;
 
 use Laravel\Prompts\Key;
 use PHPUnit\Framework\Attributes\Test;
+use SoloTerm\Solo\Commands\Command;
 use SoloTerm\Solo\Commands\EnhancedTailCommand;
 
 class HotkeyTest extends Base
@@ -28,13 +29,32 @@ class HotkeyTest extends Base
             function (string $ansi, string $plain) {
                 $this->assertStringNotContainsString('GitHub: https://github.com/aarondfrancis/solo', $plain);
             },
+            '$',    // expected to move to the tail tab
+            function (string $ansi, string $plain) {
+                $this->assertStringContainsString('php artisan test', $plain);
+            },
+            'l',    // expected to move to the head tab
+            'h',    // expected to move to the tail tab
+            function (string $ansi, string $plain) {
+                $this->assertStringContainsString('php artisan test', $plain);
+            },
+            'h',
+            function (string $ansi, string $plain) {
+                $this->assertStringContainsString('php artisan queue:work', $plain);
+            },
+            '^',    // expected to move to the head tab
+            function (string $ansi, string $plain) {
+                $this->assertStringContainsString('GitHub: https://github.com/aarondfrancis/solo', $plain);
+            },
         ];
 
         $this->runSolo($actions, function () {
             config()->set('solo.keybinding', 'vim');
             config()->set('solo.commands', [
                 'About' => 'php artisan solo:about',
-                'Logs' => 'tail -f -n 100 ' . storage_path('logs/laravel.log')
+                'Logs' => EnhancedTailCommand::file(storage_path('logs/laravel.log')),
+                'Queue' => Command::from('php artisan queue:work')->lazy(),
+                'Test' => Command::from('php artisan test')->lazy(),
             ]);
         });
     }
@@ -47,18 +67,39 @@ class HotkeyTest extends Base
             function (string $ansi, string $plain) {
                 $this->assertStringContainsString('Hide vendor', $plain);
             },
-            Key::RIGHT_ARROW,
             'v',
+            function (string $ansi, string $plain) {
+                $this->assertStringContainsString('Show vendor', $plain);
+            },
             Key::RIGHT_ARROW,
             function (string $ansi, string $plain) {
-                $this->assertStringContainsString('Hide vendor', $plain);
+                $this->assertStringContainsString('php artisan queue:work', $plain);
+            },
+            "\e[1;5D",  // CTRL + LEFT_ARROW : expected to move to the head tab
+            function (string $ansi, string $plain) {
+                $this->assertStringContainsString('php artisan solo:about', $plain);
+            },
+            Key::RIGHT_ARROW,
+            "\e[1;5C",  // CTRL + RIGHT_ARROW : expected to move to the tail tab
+            function (string $ansi, string $plain) {
+                $this->assertStringContainsString('php artisan test', $plain);
+            },
+            Key::RIGHT_ARROW,   // expected to move to the head tab
+            function (string $ansi, string $plain) {
+                $this->assertStringContainsString('php artisan solo:about', $plain);
+            },
+            Key::LEFT_ARROW,    // expected to move to the tail tab
+            function (string $ansi, string $plain) {
+                $this->assertStringContainsString('php artisan test', $plain);
             },
         ];
 
         $this->runSolo($actions, function () {
             config()->set('solo.commands', [
                 'About' => 'php artisan solo:about',
-                'Logs' => EnhancedTailCommand::file(storage_path('logs/laravel.log'))
+                'Logs' => EnhancedTailCommand::file(storage_path('logs/laravel.log')),
+                'Queue' => Command::from('php artisan queue:work')->lazy(),
+                'Test' => Command::from('php artisan test')->lazy(),
             ]);
         });
     }


### PR DESCRIPTION
This PR adds some hotkeys:

`SoloTerm\Solo\Hotkeys\DefaultHotkeys`:

- `Ctrl` + `Left` arrow : to jump to the leftmost tab
- `Ctrl` + `Right` arrow : to jump to the rightmost tab

`SoloTerm\Solo\Hotkeys\VimHotkeys`:

- `^` : to jump to the leftmost tab
- `$` : to jump to the rightmost tab