### PR TITLE
Add return type declarations to withProcess and withEnv

### DIFF
--- a/src/Commands/Concerns/ManagesProcess.php
+++ b/src/Commands/Concerns/ManagesProcess.php
@@ -199,14 +199,14 @@ trait ManagesProcess
         }
     }
 
-    public function withProcess(Closure $cb)
+    public function withProcess(Closure $cb): static
     {
         $this->processModifier = $cb;
 
         return $this;
     }
 
-    public function withEnv(array $env)
+    public function withEnv(array $env): static
     {
         $this->environment = $env;
 


### PR DESCRIPTION
Adding the missing types for these methods lets the default `config/solo.php` pass Larastan's level 10 requirements